### PR TITLE
Added $data to get request

### DIFF
--- a/library/WPAPI.php
+++ b/library/WPAPI.php
@@ -133,8 +133,8 @@ class WPAPI {
 	/**
 	 * Send a GET request
 	 */
-	public function get($endpoint, $headers = array(), $options = array()) {
-		return $this->request($endpoint, $headers, array(), Requests::GET, $options);
+	public function get($endpoint, $headers = array(), $data = array(), $options = array()) {
+		return $this->request($endpoint, $headers, $data, Requests::GET, $options);
 	}
 	/**
 	 * Send a HEAD request


### PR DESCRIPTION
No issue.

Previously there's no way to pass down query parameters to a get request using the `WPAPI` class. This change enables to filter posts/pages/cpts as per http://wp-api.org/#posts_retrieve-posts_input.
